### PR TITLE
Adding Event Listeners for the Sliders + refactor

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,13 +21,7 @@
       </div>
 
       <!-- This will hold the Legend for the Sliders -->
-      <div id="legend-container">
-        <!-- <div class="expense-container">
-          <p id="expense-name" class="medium-text">Food</p>
-          <div id="expense-box">Box</div>
-          <p id="expense-value" class="medium-text">100 EUR</p>
-        </div> -->
-      </div>
+      <div id="legend-container"></div>
 
       <!-- This will be the container for Buttons -->
       <div id="button-container">

--- a/js/Components/CircularSlider.js
+++ b/js/Components/CircularSlider.js
@@ -17,8 +17,6 @@ export default class CircularSlider {
     this.sliderColor = options.color
     this.sliderName = options.name
 
-    this.mouseDown = false
-    this.activeSlider = null
     this.cx = this.sliderSvgWidth / 2
     this.cy = this.sliderSvgHeight / 2
     this.sliderValue = this.minSliderValue
@@ -26,6 +24,10 @@ export default class CircularSlider {
 
     this.emptySliderColor = '#888888'
     this.sliderStrokeWidth = 25
+
+    this.mouseDown = false
+    this.mouseMove = false
+    this.activeSliderGroup = null
 
     this.createLegend()
   }
@@ -41,15 +43,171 @@ export default class CircularSlider {
       'rotate(-90,' + this.cx + ',' + this.cy + ')',
     )
     sliderGroup.setAttribute('rad', this.radius)
+    sliderGroup.setAttribute('maxSliderValue', this.maxSliderValue)
+    sliderGroup.setAttribute('minSliderValue', this.minSliderValue)
+    sliderGroup.setAttribute('sliderStep', this.step)
     svg.appendChild(sliderGroup)
 
     // First Draw Empty Slider
     this.drawArcPath(this.emptySliderColor, 360, 'inactive', sliderGroup)
-
     // Then we draw the Active slider
     this.drawArcPath(this.sliderColor, 0, 'active', sliderGroup)
     // Finally we have to draw the Knob
     this.drawKnob(sliderGroup, 0)
+
+    // Attach Event Handlers
+    this.attachEventListeners(this.sliderContainer)
+  }
+
+  drawKnob(svgGroup, angle) {
+    const knobCenter = MathUtils.getPointOnCircumference(
+      this.cx,
+      this.cy,
+      MathUtils.degreeToRadian(angle),
+      this.radius,
+    )
+
+    const knob = document.createElementNS(
+      'http://www.w3.org/2000/svg',
+      'circle',
+    )
+    knob.id = 'knob-' + this.radius
+    knob.setAttribute('cx', knobCenter.x)
+    knob.setAttribute('cy', knobCenter.y)
+    knob.setAttribute('r', this.sliderStrokeWidth / 2)
+    knob.style.stroke = KnobModel.strokeColor
+    knob.style.strokeWidth = KnobModel.strokeWidth
+    knob.style.fill = KnobModel.fillColor
+    svgGroup.appendChild(knob)
+  }
+
+  createLegend() {
+    console.log('Creating Legend')
+    const expenseContainer = document.createElement('div')
+    expenseContainer.classList.add('expense-container')
+    expenseContainer.id = 'expense-container-' + this.radius
+
+    const expenseName = document.createElement('p')
+    expenseName.classList.add('medium-text')
+    expenseName.id = 'expense-name'
+    expenseName.innerHTML = this.sliderName
+
+    const expenseBox = document.createElement('div')
+    expenseBox.style.backgroundColor = this.sliderColor
+    expenseBox.classList.add('expense-box')
+
+    const expenseValue = document.createElement('p')
+    expenseValue.classList.add('medium-text')
+    expenseValue.id = 'expense-value'
+    expenseValue.innerHTML = this.sliderValue + ' EUR'
+
+    expenseContainer.appendChild(expenseName)
+    expenseContainer.appendChild(expenseBox)
+    expenseContainer.appendChild(expenseValue)
+
+    document.getElementById('legend-container').appendChild(expenseContainer)
+  }
+
+  updateUI(newPoint) {
+    // Do not search for new Slider if we are performing 'mouseMove'
+    if (!this.mouseMove)
+      this.activeSliderGroup = this.findClosestSlider(newPoint)
+    const activeSliderRadius = +this.activeSliderGroup.getAttribute('rad')
+    const currentAngle =
+      MathUtils.getAngleOnCircleBetweenPointAndY(newPoint, this.cx, this.cy) *
+      0.999
+
+    // update Slider
+    this.updateSlider(activeSliderRadius, currentAngle)
+
+    // update Knob
+    this.updateKnob(activeSliderRadius, currentAngle)
+
+    // update Legend
+    this.updateLegend(activeSliderRadius, currentAngle)
+  }
+
+  updateSlider(activeSliderRadius, currentAngle) {
+    const activePath = this.activeSliderGroup.querySelector('#active')
+    const arcPath = this.generateArcPath(
+      this.cx,
+      this.cy,
+      activeSliderRadius,
+      MathUtils.radianToDegrees(currentAngle),
+    )
+
+    activePath.setAttribute(
+      'd',
+      `M ${arcPath.M.mx} ${arcPath.M.my} A ${arcPath.A.rx} ${arcPath.A.ry} ${arcPath.A.xRotation} ${arcPath.A.arcSweep} ${arcPath.A.largeArc} ${arcPath.A.endX} ${arcPath.A.endY} ${arcPath.Z}`,
+    )
+  }
+
+  updateKnob(activeSliderRadius, currentAngle) {
+    const knobId = '#knob-' + activeSliderRadius
+    const knob = this.activeSliderGroup.querySelector(knobId)
+    const knobCenter = MathUtils.getPointOnCircumference(
+      this.cx,
+      this.cy,
+      currentAngle,
+      activeSliderRadius,
+    )
+    knob.setAttribute('cx', knobCenter.x)
+    knob.setAttribute('cy', knobCenter.y)
+  }
+
+  updateLegend(activeSliderRadius, currentAngle) {
+    const expenseContainer = document.querySelector(
+      '#expense-container-' + activeSliderRadius,
+    )
+
+    // Get the Active slider's expenseValue element from the Container
+    const expenseValue = Array.from(expenseContainer.children).filter(
+      (element) => {
+        return element.id === 'expense-value'
+      },
+    )[0]
+
+    // Get the Max/Min/Step values from Active Slider's Attributes
+    const maxSliderValue = parseInt(
+      this.activeSliderGroup.getAttribute('maxSliderValue'),
+    )
+    const minSliderValue = parseInt(
+      this.activeSliderGroup.getAttribute('minSliderValue'),
+    )
+    const sliderStep = parseInt(
+      this.activeSliderGroup.getAttribute('sliderStep'),
+    )
+
+    const currentSliderRange = maxSliderValue - minSliderValue
+    let currentValue = (currentAngle / (2 * Math.PI)) * currentSliderRange
+    const numOfSteps = Math.round(currentValue / sliderStep)
+    currentValue = minSliderValue + numOfSteps * sliderStep
+    expenseValue.innerHTML = currentValue + ' EUR'
+  }
+
+  attachEventListeners(sliderContainer) {
+    sliderContainer.addEventListener(
+      'mousedown',
+      this.mouseTouchStart.bind(this),
+      false,
+    )
+    sliderContainer.addEventListener(
+      'touchstart',
+      this.mouseTouchStart.bind(this),
+      false,
+    )
+    sliderContainer.addEventListener(
+      'mousemove',
+      this.mouseTouchMove.bind(this),
+      false,
+    )
+    sliderContainer.addEventListener(
+      'touchmove',
+      this.mouseTouchMove.bind(this),
+      false,
+    )
+    window.addEventListener('mouseup', this.mouseTouchEnd.bind(this), false)
+    window.addEventListener('touchend', this.mouseTouchEnd.bind(this), false)
   }
 
   drawArcPath(sliderColor, currentAngle, type, sliderGroup) {
@@ -60,8 +218,6 @@ export default class CircularSlider {
       this.radius,
       currentAngle,
     )
-
-    console.log(arcPath)
 
     const path = document.createElementNS('http://www.w3.org/2000/svg', 'path')
     path.id = pathId
@@ -98,8 +254,8 @@ export default class CircularSlider {
       z = true
     }
 
-    moveToX = x + this.radius * Math.cos(MathUtils.degreeToRadian(angle))
-    moveToY = y + this.radius * Math.sin(MathUtils.degreeToRadian(angle))
+    moveToX = x + radius * Math.cos(MathUtils.degreeToRadian(angle))
+    moveToY = y + radius * Math.sin(MathUtils.degreeToRadian(angle))
 
     // We are always drawing our arc from the 0 degree angle
     //  x=cx+rx*cos(theta) and y=cy+ry*sin(theta)
@@ -132,50 +288,78 @@ export default class CircularSlider {
     return path
   }
 
-  drawKnob(svgGroup, angle) {
-    const knobCenter = MathUtils.getKnobCenter(
-      this.cx,
-      this.cy,
-      MathUtils.degreeToRadian(angle),
-      this.radius,
-    )
+  mouseTouchStart(e) {
+    if (this.mouseDown) return
+    this.mouseDown = true
+    const newPoint = this.getRelativeMouseOrTouchCoordinates(e)
 
-    const knob = document.createElementNS(
-      'http://www.w3.org/2000/svg',
-      'circle',
-    )
-    knob.id = 'knob-' + this.radius
-    knob.setAttribute('cx', knobCenter.x)
-    knob.setAttribute('cy', knobCenter.y)
-    knob.setAttribute('r', this.sliderStrokeWidth / 2)
-    knob.style.stroke = KnobModel.strokeColor
-    knob.style.strokeWidth = KnobModel.strokeWidth
-    knob.style.fill = KnobModel.fillColor
-    svgGroup.appendChild(knob)
+    this.updateUI(newPoint)
   }
 
-  createLegend() {
-    const expenseContainer = document.createElement('div')
-    expenseContainer.classList.add('expense-container')
+  mouseTouchMove(e) {
+    if (!this.mouseDown) return
+    this.mouseMove = true
+    e.preventDefault()
+    const newPoint = this.getRelativeMouseOrTouchCoordinates(e)
 
-    const expenseName = document.createElement('p')
-    expenseName.classList.add('medium-text')
-    expenseName.id = 'expense-name'
-    expenseName.innerHTML = this.sliderName
+    this.updateUI(newPoint)
+  }
 
-    const expenseBox = document.createElement('div')
-    expenseBox.style.backgroundColor = this.sliderColor
-    expenseBox.classList.add('expense-box')
+  mouseTouchEnd() {
+    if (!this.mouseDown) return
+    this.mouseDown = false
+    this.mouseMove = false
+    this.activeSliderGroup = null
+  }
 
-    const expenseValue = document.createElement('p')
-    expenseValue.classList.add('medium-text')
-    expenseValue.id = 'expense-value'
-    expenseValue.innerHTML = this.sliderValue + 'EUR'
+  getRelativeMouseOrTouchCoordinates(e) {
+    const containerRect = document
+      .querySelector('#svg-container')
+      .getBoundingClientRect()
+    let x, y, clientPosX, clientPosY
 
-    expenseContainer.appendChild(expenseName)
-    expenseContainer.appendChild(expenseBox)
-    expenseContainer.appendChild(expenseValue)
+    // Touch Event triggered
+    if (e instanceof TouchEvent) {
+      clientPosX = e.touches[0].pageX
+      clientPosY = e.touches[0].pageY
+    }
+    // Mouse Event Triggered
+    else {
+      clientPosX = e.clientX
+      clientPosY = e.clientY
+    }
 
-    document.getElementById('legend-container').appendChild(expenseContainer)
+    // Get Relative Position
+    x = clientPosX - containerRect.left
+    y = clientPosY - containerRect.top
+
+    return {x, y}
+  }
+
+  findClosestSlider(newPoint) {
+    // Get the Hypotenuse of the right triangle that is always formed
+    // from the CenterPoint of Slider towards the NewPoint
+    // this is basically the distance of the newPoint from the sliderCenter
+    const newPointDistanceFromCenter = Math.hypot(
+      newPoint.x - this.cx,
+      newPoint.y - this.cy,
+    )
+    const container = document.querySelector('#svg-container')
+    // Get all the sliders that we currently have on Canvas
+    const sliderGroups = Array.from(container.querySelectorAll('g'))
+
+    // Get distances from newPoint to each slider
+    const distances = sliderGroups.map((slider) => {
+      const radius = parseInt(slider.getAttribute('rad'))
+      // Get the absolute value of the distance between newPoint and current Slider
+      // newPointDistanceFromCenter - slider Radius gives us this distance
+      return Math.abs(newPointDistanceFromCenter - radius)
+    })
+
+    // Find the Index of the distance that is closest to the Slider
+    // the closest slider is the one that has the lowest distance between
+    // newPoint and slider
+    const closestSliderIndex = distances.indexOf(Math.min(...distances))
+    return sliderGroups[closestSliderIndex]
   }
 }

--- a/js/Models/KnobModel.js
+++ b/js/Models/KnobModel.js
@@ -1,7 +1,5 @@
 export default class KnobModel {
   static strokeColor = '#a7c0cd'
-
   static fillColor = '#fff'
-
   static strokeWidth = 3
 }

--- a/js/Models/SliderOptions.js
+++ b/js/Models/SliderOptions.js
@@ -4,10 +4,10 @@ export default class SliderOptions {
   constructor(_container, _color, _maxValue, _minValue, _step, _radius, _name) {
     this.container = _container
     this.color = _color
-    this.maxValue = _maxValue
-    this.minValue = _minValue
-    this.step = _step
-    this.radius = _radius
+    this.maxValue = parseInt(_maxValue)
+    this.minValue = parseInt(_minValue)
+    this.step = parseInt(_step)
+    this.radius = parseInt(_radius)
     this.name = _name
   }
 

--- a/js/Utilities/MathUtils.js
+++ b/js/Utilities/MathUtils.js
@@ -1,10 +1,33 @@
 export const getCircumference = (radius) => 2 * Math.PI * radius
-export const getKnobCenter = (cx, cy, angle, radius) => {
+export const getPointOnCircumference = (cx, cy, angle, radius) => {
+  // https://www.mathopenref.com/coordparamcircle.html
+  // Parametric Equation of a Circle
   const x = cx + Math.cos(angle) * radius
   const y = cy + Math.sin(angle) * radius
   return {x, y}
 }
 
 export const degreeToRadian = (angleDegrees) => {
-  return angleDegrees * ((2 * Math.PI) / 360)
+  return angleDegrees * (Math.PI / 180)
+}
+
+export const radianToDegrees = (angleRadians) => {
+  return angleRadians / (Math.PI / 180)
+}
+
+export const getAngleOnCircleBetweenPointAndY = (newPoint, cx, cy) => {
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atan2
+  // atan2 returns the angle between positive x-axis and the ray from centerPoint to newPoint
+  const deltaX = newPoint.x - cx
+  const deltaY = newPoint.y - cy
+
+  // In order to calculate the angle between the Y-axis and the Point, we need to inverse the deltaX and deltaY
+  // additionally, since our system works ClockWise, we have to change the sign of Y to negative (axis direction down)
+  const angleRad = Math.atan2(deltaX, -deltaY)
+
+  // Once the angle moves from positive X-axis towards negative
+  // our atan2 function returns the negative value, since it now calcultes from negative X-axis
+  // we adjust this, by adding 2 * Math.PI to our angleRad
+  const radian360 = angleRad < 0 ? angleRad + 2 * Math.PI : angleRad
+  return radian360
 }


### PR DESCRIPTION
In this commit I am adding Event Listeners for Mouse and Touch events. We move the sliders using following principle:
1. Find the Closest Slider to the Mouse / Touch Event (findClosestSlider(newPoint))
2. Once we get the closest Slider, we set it as 'Active' Slider
3. Then we calculate the Angle on Circle Between the Mouse/Touch point and the center of Slider
4. Now we are able to update the Sliders, Knob and Legend 

I also did quite some refactoring of the code to try and make it more easily to navigate around it.