### PR TITLE
Adding Snappy feature for movement

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2,7 +2,7 @@
   width: 100%;
   height: 100%;
   display: grid;
-  grid-template-rows: 50px 1fr 100px 50px;
+  grid-template-rows: 50px 1fr 200px 50px;
   grid-template-areas:
     'header'
     'main'
@@ -12,15 +12,15 @@
 
 #title-container {
   background-color: aqua;
+  display: flex;
+  justify-content: center;
   grid-area: header;
 }
 
 #main-container {
+  display: flex;
+  justify-content: center;
   grid-area: main;
-}
-
-#svg-container {
-  min-width: 100%;
 }
 
 #legend-container {
@@ -29,19 +29,9 @@
 
 /* BUTTON STYLES */
 #button-container {
-  background-color: brown;
   grid-area: button;
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-template-areas: 'create generate';
-}
-
-#btn-create-slider {
-  grid-area: create;
-}
-
-#btn-generate-random {
-  grid-area: generate;
+  display: flex;
+  justify-content: space-evenly;
 }
 
 /* EXPENSE STYLES */
@@ -87,10 +77,10 @@
   /* For Desktop */
   #grid-container {
     grid-template-columns: 30% 1fr 1fr 1fr;
-    grid-template-rows: 100px auto;
+    grid-template-rows: 100px 1fr 80px;
     grid-template-areas:
       'header header header header'
-      'legend main main main'
+      'legend main main .'
       '. button button .';
   }
 
@@ -102,9 +92,24 @@
     font-size: 1.5rem;
   }
 
-  .expense-container {
-    justify-items: start;
-    grid-template-columns: 1fr 1fr 1fr 20% 10% 20%;
-    grid-template-areas: '. . . name expcolor value';
+  #legend-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+  }
+
+  #button-container {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-gap: 50px;
+    grid-template-areas: 'create generate';
+  }
+
+  #btn-create-slider {
+    grid-area: create;
+  }
+
+  #btn-generate-random {
+    grid-area: generate;
   }
 }

--- a/js/Models/SliderOptions.js
+++ b/js/Models/SliderOptions.js
@@ -1,7 +1,16 @@
 import * as StringConstants from '../Constants/StringConstants.js'
 
 export default class SliderOptions {
-  constructor(_container, _color, _maxValue, _minValue, _step, _radius, _name) {
+  constructor(
+    _container,
+    _color,
+    _maxValue,
+    _minValue,
+    _step,
+    _radius,
+    _name,
+    _smoothScroll,
+  ) {
     this.container = _container
     this.color = _color
     this.maxValue = parseInt(_maxValue)
@@ -9,6 +18,7 @@ export default class SliderOptions {
     this.step = parseInt(_step)
     this.radius = parseInt(_radius)
     this.name = _name
+    this.smoothScroll = _smoothScroll
   }
 
   validateOptions() {

--- a/js/Utilities/MathUtils.js
+++ b/js/Utilities/MathUtils.js
@@ -31,3 +31,9 @@ export const getAngleOnCircleBetweenPointAndY = (newPoint, cx, cy) => {
   const radian360 = angleRad < 0 ? angleRad + 2 * Math.PI : angleRad
   return radian360
 }
+
+export const getSnappyAngleInRadian = (angleDeg, stepAngle) => {
+  const currentSteps = Math.ceil(angleDeg / stepAngle)
+  const currentStepAngle = currentSteps * stepAngle
+  return degreeToRadian(currentStepAngle)
+}

--- a/main.js
+++ b/main.js
@@ -5,16 +5,16 @@ import * as StringConstants from './js/Constants/StringConstants.js'
 import * as SvgUtils from './js/Utilities/SvgUtils.js'
 
 // Constants
-const SVG_HEIGHT = InterfaceUtils.isMobileDevice() ? 250 : 400
-const SVG_WIDTH = InterfaceUtils.isMobileDevice() ? 250 : 400
-const MAX_RADIUS = InterfaceUtils.isMobileDevice() ? 40 : 160
-const STEP_RADIUS = InterfaceUtils.isMobileDevice() ? 30 : 60
+const SVG_HEIGHT = InterfaceUtils.isMobileDevice() ? 400 : 400
+const SVG_WIDTH = InterfaceUtils.isMobileDevice() ? 400 : 400
+const MAX_RADIUS = InterfaceUtils.isMobileDevice() ? 160 : 160
+const STEP_RADIUS = InterfaceUtils.isMobileDevice() ? 60 : 60
 
 // Main Containerrs
 const mainContainer = document.getElementById('main-container')
 const svgContainer = document.getElementById('svg-container')
-svgContainer.setAttribute('width', SVG_WIDTH)
-svgContainer.setAttribute('height', SVG_HEIGHT)
+svgContainer.style.width = SVG_WIDTH
+svgContainer.style.height = SVG_HEIGHT
 
 // Global varaibles
 let nrExistingSliders = 0
@@ -49,6 +49,9 @@ function generateSliderOptions() {
   const minimumValue = prompt('Please enter starting value for Slider', 0)
   const maximumValue = prompt('Please enter maximum value for Slider', 100)
   const stepValue = prompt('Please enter Step value for Slider', 10)
+  let smoothScroll = prompt('Do you want to use smooth scrolling? [Y/n]', 'Y')
+  if (smoothScroll === 'Y') smoothScroll = true
+  else smoothScroll = false
 
   const radius = InterfaceUtils.getSliderRadius(
     nrExistingSliders,
@@ -66,6 +69,7 @@ function generateSliderOptions() {
     stepValue,
     radius,
     sliderName,
+    smoothScroll,
   )
 
   // Validate Slider Options


### PR DESCRIPTION
I decided to add Snappiness feature for moving the Sliders with step values that are a quite large in comparisson to the Max slider value. 

With smooth scrolling OFF,  the slider will move only to the 'fixed' value at once. 
With smooth scrolling ON, the slider will move smoothly as you pull and will not snap to the 'step' value, but rather stay where you pulled it. 