### PR TITLE
Adding Snap Treshold feature + code refacorting

### DIFF
--- a/js/Utilities/MathUtils.js
+++ b/js/Utilities/MathUtils.js
@@ -32,8 +32,14 @@ export const getAngleOnCircleBetweenPointAndY = (newPoint, cx, cy) => {
   return radian360
 }
 
-export const getSnappyAngleInRadian = (angleDeg, stepAngle) => {
+export const getCurrentStep = (angleDeg, stepAngleDeg) =>
+  Math.ceil(angleDeg / stepAngleDeg)
+
+export const getCurrentStepAngleDeg = (currentStep, currentStepAngleDeg) =>
+  currentStep * currentStepAngleDeg
+
+export const getSnappyAngleInDegrees = (angleDeg, stepAngle) => {
   const currentSteps = Math.ceil(angleDeg / stepAngle)
   const currentStepAngle = currentSteps * stepAngle
-  return degreeToRadian(currentStepAngle)
+  return currentStepAngle
 }


### PR DESCRIPTION
Adding a feature so that sliders do not instantly snap to next value as soon as you click next to Knob.

The current treshold is set to 0.1  of the next Snap Angle. 

I also did some code refactoring to make the angle variables more meaningful whether they represent the value in Radians or Degrees.